### PR TITLE
Fixed delete buttons for Elevated Priv. Account View in Areas\Admin\Views\ElevatedAccount

### DIFF
--- a/BTT/BeyondTheTutor/BeyondTheTutor/Areas/Admin/Controllers/ElevatedAccountController.cs
+++ b/BTT/BeyondTheTutor/BeyondTheTutor/Areas/Admin/Controllers/ElevatedAccountController.cs
@@ -17,12 +17,13 @@
     public class ElevatedAccountController : Controller
     {
         private BeyondTheTutorContext db = new BeyondTheTutorContext();
+        private ApplicationDbContext context = new ApplicationDbContext();
 
 
         // GET: Admin/Tutors
-        public async Task<ActionResult> IndexAsync()
+        public async Task<ActionResult> Index()
         {
-            ViewBag.Current = "AdminElevatedAccountIndexAsync";
+            ViewBag.Current = "AdminElevatedAccountIndex";
             var tutorsIn = db.Tutors.Include(t => t.BTTUser);
             var professorsIn = db.Professors.Include(t => t.BTTUser);
 
@@ -80,21 +81,6 @@
             }
 
             return View(usersOut);
-        }
-
-        // GET: Admin/Tutors/Details/5
-        public ActionResult Details(int? id)
-        {
-            if (id == null)
-            {
-                return new HttpStatusCodeResult(HttpStatusCode.BadRequest);
-            }
-            Tutor tutor = db.Tutors.Find(id);
-            if (tutor == null)
-            {
-                return HttpNotFound();
-            }
-            return View(tutor);
         }
 
         // GET: Admin/Tutors/Create
@@ -166,25 +152,92 @@
                 }
 
 
-                return RedirectToAction("IndexAsync");
+                return RedirectToAction("Index");
             }
             ViewBag.ID = new SelectList(db.BTTUsers, "ID", "FirstName", tutor.ID);
             return View(tutor);
         }
 
-        // GET: Admin/Tutors/Delete/5
+        // GET: Admin/BTTusers/delete/5
         public ActionResult Delete(int? id)
         {
             if (id == null)
             {
                 return new HttpStatusCodeResult(HttpStatusCode.BadRequest);
             }
-            Tutor tutor = db.Tutors.Find(id);
-            if (tutor == null)
+            BTTUser user = db.BTTUsers.Find(id);
+            if (user == null)
             {
                 return HttpNotFound();
             }
-            return View(tutor);
+            return View(user);
+        }
+
+        // POST: Admin/TutorSchedules/Delete/5
+        [HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        public ActionResult DeleteConfirmed(int id)
+        {
+            if (ModelState.IsValid)
+            {
+                if (id == null)
+                {
+                    return new HttpStatusCodeResult(HttpStatusCode.BadRequest);
+                }
+
+                //initialize a user manager
+                var UserManager = new UserManager<ApplicationUser>(new UserStore<ApplicationUser>(context));
+
+
+                BTTUser user = db.BTTUsers.Find(id); //get Account BeyondTheTutor (DATA)
+                var aspAccount = UserManager.FindById(user.ASPNetIdentityID); //get Account AspAccountIdentity (DATA)
+
+                //information about 3rd party/external logins, for example users who login into our site via Google, Facebook, Twitter etc
+                var logins = aspAccount.Logins;
+
+                var accountRoles = UserManager.GetRoles(aspAccount.Id); //get roles
+
+                //viewbag printouts for Target Account
+                var accountEmail = aspAccount.Email.ToString(); // get email of account being deleted
+                var firstName = user.FirstName; // first and
+                var lastName = user.LastName; // last name
+                var accountRole = UserManager.GetRoles(aspAccount.Id).FirstOrDefault().ToString();
+                //eof viewbag printouts
+
+
+                db.BTTUsers.Remove(user); //remove BeyondTheTutor Account's (DATA)
+                db.SaveChanges();
+
+
+                using (var transaction = context.Database.BeginTransaction())
+                {
+                    foreach (var login in logins.ToList())
+                    {
+                        UserManager.RemoveLogin(login.UserId, new UserLoginInfo(login.LoginProvider, login.ProviderKey));
+                    }
+
+                    if (accountRoles.Count() > 0)
+                    {
+                        foreach (var item in accountRoles.ToList())
+                        {
+                            // item should be the name of the role
+                            var result = UserManager.RemoveFromRole(aspAccount.Id, item);
+                        }
+                    }
+
+                    UserManager.Delete(aspAccount);
+                    transaction.Commit();
+                }
+
+                TempData["f"] = "You have successfully removed a " + accountRole + ": " + firstName + " " + lastName + ", " + accountEmail + "";
+
+                return RedirectToAction("Index");
+            }
+            else
+            {
+                ViewBag.f = "Something went wrong. Please make sure your action was valid.";
+                return View();
+            }
         }
 
         // GET: Admin/Tutors/Edit/5
@@ -231,48 +284,13 @@
                 }
 
 
-                return RedirectToAction("IndexAsync");
+                return RedirectToAction("Index");
             }
             ViewBag.ID = new SelectList(db.BTTUsers, "ID", "FirstName", professor.ID);
             return View(professor);
         }
 
-        // POST: Admin/Tutors/Delete/5
-        [HttpPost, ActionName("Delete")]
-        [ValidateAntiForgeryToken]
-        public ActionResult DeleteConfirmed(int id)
-        {
-            Tutor tutor = db.Tutors.Find(id);
-            db.Tutors.Remove(tutor);
-            db.SaveChanges();
-            return RedirectToAction("Index");
-        }
 
-        // GET: Admin/Tutors/DeleteProf/5
-        public ActionResult DeleteProf(int? id)
-        {
-            if (id == null)
-            {
-                return new HttpStatusCodeResult(HttpStatusCode.BadRequest);
-            }
-            Professor professor = db.Professors.Find(id);
-            if (professor == null)
-            {
-                return HttpNotFound();
-            }
-            return View(professor);
-        }
-
-        // POST: Admin/Tutors/DeleteProf/5
-        [HttpPost, ActionName("DeleteProf")]
-        [ValidateAntiForgeryToken]
-        public ActionResult DeleteConfirmedProf(int id)
-        {
-            Professor professor = db.Professors.Find(id);
-            db.Professors.Remove(professor);
-            db.SaveChanges();
-            return RedirectToAction("Index");
-        }
 
         protected override void Dispose(bool disposing)
         {

--- a/BTT/BeyondTheTutor/BeyondTheTutor/Areas/Admin/Views/ElevatedAccount/Delete.cshtml
+++ b/BTT/BeyondTheTutor/BeyondTheTutor/Areas/Admin/Views/ElevatedAccount/Delete.cshtml
@@ -1,0 +1,53 @@
+﻿@using BeyondTheTutor.DAL;
+@using BeyondTheTutor.Models.ViewModels;
+@using Microsoft.AspNet.Identity;
+@using Microsoft.AspNet.Identity.EntityFramework;
+@model BeyondTheTutor.Models.BTTUser
+
+@{
+    BeyondTheTutorContext db = new BeyondTheTutorContext();
+    ApplicationDbContext context = new ApplicationDbContext();
+
+    var UserManager = new UserManager<ApplicationUser>(new UserStore<ApplicationUser>(context));
+    var accountEmail = UserManager.GetEmail(Model.ASPNetIdentityID);
+
+    ViewBag.First = Html.DisplayFor(model => model.FirstName);
+    ViewBag.Last = Html.DisplayFor(model => model.LastName);
+    ViewBag.Email = accountEmail.ToString();
+}
+
+<body class="wou-silver-bg">
+    <div class="ui one column stackable page grid">
+        <div class="ui red message schedule"><i class="close icon"></i>Careful! Once you delete this user, there's no turning back.</div>
+        <div class="ui form attached fluid segment">
+            <div class="three fields">
+                <div class="field">
+                    <h4>Firstname</h4>
+                    @Html.DisplayFor(model => model.FirstName)
+                </div>
+                <div class="field">
+                    <h4>Lastname</h4>
+                    @Html.DisplayFor(model => model.LastName)
+                </div>
+                <div class="field">
+                    <h4>Email</h4>
+                    @ViewBag.Email
+                </div>
+            </div>
+            @using (Html.BeginForm())
+            {
+                @Html.AntiForgeryToken()
+
+                <div class="form-actions no-color">
+                    <button type="submit" value="Delete" class="fluid ui button schedule" style="margin-bottom: 3px;">DELETE @ViewBag.First @ViewBag.Last</button>
+                    <a href="/Admin/ElevatedAccount/Index" button class="fluid ui button schedule">Go Back to List</a>
+                </div>
+            }
+        </div>
+    </div>
+</body>
+
+@section scripts
+{
+    <script src="~/Scripts/main.js"></script>
+}

--- a/BTT/BeyondTheTutor/BeyondTheTutor/Areas/Admin/Views/ElevatedAccount/Index.cshtml
+++ b/BTT/BeyondTheTutor/BeyondTheTutor/Areas/Admin/Views/ElevatedAccount/Index.cshtml
@@ -72,7 +72,6 @@ else if (ViewBag.F != null)
                                         <i class="icon lock"></i>
                                         @Html.ActionLink("Disapprove", "UpdateTutor", new { id = item.ID })
                                     </button>
-
                                 }
                             }
                             else

--- a/BTT/BeyondTheTutor/BeyondTheTutor/Areas/Admin/Views/Shared/_Layout.cshtml
+++ b/BTT/BeyondTheTutor/BeyondTheTutor/Areas/Admin/Views/Shared/_Layout.cshtml
@@ -18,7 +18,7 @@
                 <i class="dropdown icon"></i>
                 <div class="menu">
                     @Html.ActionLink("Remove a User", "Index", "AllUsers", new { area = "admin" }, htmlAttributes: new { @class = (ViewBag.Current == "AdminAllUsersIndex" ? "item red active" : "item") })
-                    @Html.ActionLink("Approval Pending Users", "IndexAsync", "ElevatedAccount", new { area = "admin" }, htmlAttributes: new { @class = (ViewBag.Current == "AdminElevatedAccountIndexAsync" ? "item red active" : "item") })
+                    @Html.ActionLink("Approval Pending Users", "Index", "ElevatedAccount", new { area = "admin" }, htmlAttributes: new { @class = (ViewBag.Current == "AdminElevatedAccountIndex" ? "item red active" : "item") })
                     @Html.ActionLink("Create an Admin", "CreateAdmin", "AllUsers", new { area = "admin" }, htmlAttributes: new { @class = (ViewBag.Current == "CreateAdmin" ? "item red active" : "item") })
                 </div>
             </div>

--- a/BTT/BeyondTheTutor/BeyondTheTutor/BeyondTheTutor.csproj
+++ b/BTT/BeyondTheTutor/BeyondTheTutor/BeyondTheTutor.csproj
@@ -218,10 +218,6 @@
   <ItemGroup>
     <Content Include="App_Data\AspDown.sql" />
     <Content Include="App_Data\AspUp.sql" />
-    <Content Include="App_Data\BeyondTheTutor.mdf" />
-    <Content Include="App_Data\BeyondTheTutor_log.ldf">
-      <DependentUpon>BeyondTheTutor.mdf</DependentUpon>
-    </Content>
     <Content Include="App_Data\down.sql" />
     <Content Include="App_Data\queries.sql" />
     <Content Include="App_Data\up.sql" />

--- a/BTT/BeyondTheTutor/BeyondTheTutor/BeyondTheTutor.csproj
+++ b/BTT/BeyondTheTutor/BeyondTheTutor/BeyondTheTutor.csproj
@@ -218,6 +218,10 @@
   <ItemGroup>
     <Content Include="App_Data\AspDown.sql" />
     <Content Include="App_Data\AspUp.sql" />
+    <Content Include="App_Data\BeyondTheTutor.mdf" />
+    <Content Include="App_Data\BeyondTheTutor_log.ldf">
+      <DependentUpon>BeyondTheTutor.mdf</DependentUpon>
+    </Content>
     <Content Include="App_Data\down.sql" />
     <Content Include="App_Data\queries.sql" />
     <Content Include="App_Data\up.sql" />
@@ -423,11 +427,12 @@
     <Content Include="Areas\Student\Views\Home\Guide.cshtml" />
     <Content Include="Areas\Tutor\Views\Home\Guide.cshtml" />
     <Content Include="Areas\Admin\Views\ElevatedAccount\UpdateTutor.cshtml" />
-    <Content Include="Areas\Admin\Views\ElevatedAccount\IndexAsync.cshtml" />
+    <Content Include="Areas\Admin\Views\ElevatedAccount\Index.cshtml" />
     <Content Include="Areas\Admin\Views\ElevatedAccount\UpdateProfessor.cshtml" />
     <Content Include="Areas\Admin\Views\AllUsers\Index.cshtml" />
     <Content Include="Areas\Admin\Views\AllUsers\Delete.cshtml" />
     <Content Include="Areas\Admin\Views\AllUsers\CreateAdmin.cshtml" />
+    <Content Include="Areas\Admin\Views\ElevatedAccount\Delete.cshtml" />
     <None Include="Scripts\jquery-3.4.1.intellisense.js" />
     <Compile Include="Models\ViewModels\AllUsersViewModel.cs" />
     <Content Include="Scripts\displayrequestedappts.js" />


### PR DESCRIPTION
**What's Changed**

- Wired the delete buttons to actual actions and we can now remove accounts thru the admin Elevated Priv. Account list and ALL users list. 
- Renamed IndexAsync to Index for simplicity. 
- Removed some extra divs and required Layout to match the string for highlighting active tabs.
- Added a Delete inside of Areas\Admin\Views\ElevatedAccount\. . . 