### PR TITLE
Fix status if marked as Request on date timeout

### DIFF
--- a/BTT/BeyondTheTutor/BeyondTheTutor/Areas/Student/Controllers/HomeController.cs
+++ b/BTT/BeyondTheTutor/BeyondTheTutor/Areas/Student/Controllers/HomeController.cs
@@ -34,7 +34,15 @@ namespace BeyondTheTutor.Areas.Student.Controllers
                     tutoringAppt.Status = "Completed";
 
                     db.Entry(tutoringAppt).State = EntityState.Modified;
-                    
+                } 
+                else if (DateTime.Now > appt.EndTime.AddMinutes(30) && (appt.Status == "Requested"))
+                {
+                    var currentItem = appt.ID;
+                    TutoringAppt tutoringAppt = db.TutoringAppts.Find(currentItem);
+
+                    tutoringAppt.Status = "Declined";
+
+                    db.Entry(tutoringAppt).State = EntityState.Modified;
                 }
             }
 

--- a/BTT/BeyondTheTutor/BeyondTheTutor/Areas/Student/Views/TutoringAppts/Create.cshtml
+++ b/BTT/BeyondTheTutor/BeyondTheTutor/Areas/Student/Views/TutoringAppts/Create.cshtml
@@ -35,10 +35,10 @@
                             <h4>Length</h4>
                         </div>
                         <div class="field">
-                            <h4>Type of Meeting</h4>
+                            <h4>Class</h4>
                         </div>
                         <div class="field">
-                            <h4>Class</h4>
+                            <h4>Type of Meeting</h4>
                         </div>
                     </div>
                     <div class="six fields">

--- a/BTT/BeyondTheTutor/BeyondTheTutor/Areas/Tutor/Controllers/HomeController.cs
+++ b/BTT/BeyondTheTutor/BeyondTheTutor/Areas/Tutor/Controllers/HomeController.cs
@@ -27,7 +27,15 @@ namespace BeyondTheTutor.Areas.Tutor.Controllers
                     tutoringAppt.Status = "Completed";
 
                     db.Entry(tutoringAppt).State = EntityState.Modified;
+                }
+                else if (DateTime.Now > appt.EndTime.AddMinutes(30) && (appt.Status == "Requested"))
+                {
+                    var currentItem = appt.ID;
+                    TutoringAppt tutoringAppt = db.TutoringAppts.Find(currentItem);
 
+                    tutoringAppt.Status = "Declined";
+
+                    db.Entry(tutoringAppt).State = EntityState.Modified;
                 }
             }
 


### PR DESCRIPTION
**What changed?**
- (Student View) Fixed a bug displaying the incorrect label when creating new Tutoring Request
- (Student View and Tutor View) Automatic Tutoring Request completion now accounts for requests marked as "Requested" but now out of date